### PR TITLE
Normalize QAFilter pass parsing and add coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Top-level package for the simplified RAG project."""

--- a/src/filtering/__init__.py
+++ b/src/filtering/__init__.py
@@ -1,0 +1,5 @@
+"""Filtering utilities for the RAG project."""
+
+from .filter import FilterResponse, QAFilter
+
+__all__ = ["FilterResponse", "QAFilter"]

--- a/src/filtering/filter.py
+++ b/src/filtering/filter.py
@@ -1,0 +1,96 @@
+"""Filtering logic used by the QA pipeline.
+
+This module intentionally implements only the pieces required by the unit
+suite that accompanies this kata.  The :class:`QAFilter` class exposes a
+``_parse_response`` helper which interprets responses returned by the
+underlying model and normalises their structure for downstream consumers.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, Mapping
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class FilterResponse:
+    """Container object returned by :class:`QAFilter`.
+
+    Attributes
+    ----------
+    filter_passed:
+        Indicates whether a document/question pair passed the QA filter.
+    metadata:
+        Any additional information extracted from the raw response.  The
+        metadata is intentionally permissive because different back-ends may
+        choose to return a variety of diagnostic fields.
+    """
+
+    filter_passed: bool
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+class QAFilter:
+    """Helper responsible for interpreting model responses.
+
+    The filter currently focuses on the ``"pass"`` key returned by the model.
+    Some models may return booleans, while others serialise the value as a
+    string.  ``QAFilter`` smooths over those differences by ensuring that the
+    downstream pipeline always receives a proper boolean.
+    """
+
+    _TRUTHY_STRINGS = {"true", "t", "yes", "y", "1"}
+    _FALSY_STRINGS = {"false", "f", "no", "n", "0"}
+
+    def _parse_response(self, response: Mapping[str, Any]) -> FilterResponse:
+        """Convert a raw model response into :class:`FilterResponse`.
+
+        Parameters
+        ----------
+        response:
+            Mapping returned by the model.  Only the ``"pass"`` key is
+            required, although additional diagnostic keys are preserved in the
+            resulting metadata.
+        """
+
+        if not isinstance(response, Mapping):  # pragma: no cover - defensive
+            logger.warning("Unexpected response type %s. Treating as failure.", type(response).__name__)
+            return FilterResponse(filter_passed=False, metadata={"raw": response})
+
+        raw_pass = response.get("pass")
+        filter_passed = self._normalise_pass_value(raw_pass)
+
+        metadata = {key: value for key, value in response.items() if key != "pass"}
+        if "raw" not in metadata:
+            metadata["raw"] = response
+
+        return FilterResponse(filter_passed=filter_passed, metadata=metadata)
+
+    def _normalise_pass_value(self, value: Any) -> bool:
+        """Normalise the ``"pass"`` field exposed by the model.
+
+        Real booleans are returned unchanged.  String values are interpreted in
+        a case-insensitive manner and accept a handful of common variants such
+        as ``"yes"``/``"no"``.  Anything else is considered an invalid value
+        and results in ``False`` with a warning so that the issue can be
+        diagnosed during development.
+        """
+
+        if isinstance(value, bool):
+            return value
+
+        if isinstance(value, str):
+            normalised = value.strip().lower()
+            if normalised in self._TRUTHY_STRINGS:
+                return True
+            if normalised in self._FALSY_STRINGS:
+                return False
+
+        logger.warning("Received non-boolean value for 'pass': %r. Falling back to False.", value)
+        return False
+
+
+__all__ = ["FilterResponse", "QAFilter"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+SRC_DIR = os.path.join(PROJECT_ROOT, "src")
+if SRC_DIR not in sys.path:
+    sys.path.insert(0, SRC_DIR)

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,46 @@
+import logging
+
+import pytest
+
+from filtering.filter import QAFilter
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (True, True),
+        (False, False),
+        ("true", True),
+        ("FALSE", False),
+        ("Yes", True),
+        ("no", False),
+        ("1", True),
+        ("0", False),
+    ],
+)
+def test_normalise_pass_value_handles_common_inputs(value, expected):
+    qa_filter = QAFilter()
+    assert qa_filter._normalise_pass_value(value) is expected
+
+
+def test_parse_response_handles_string_false(caplog):
+    qa_filter = QAFilter()
+    response = {"pass": "false", "reason": "The answer was incorrect."}
+
+    with caplog.at_level(logging.WARNING):
+        result = qa_filter._parse_response(response)
+
+    assert result.filter_passed is False
+    assert result.metadata["reason"] == "The answer was incorrect."
+    # No warning should be emitted for a recognised boolean string.
+    assert not any(record.levelno >= logging.WARNING for record in caplog.records)
+
+
+def test_parse_response_logs_warning_for_unexpected_value(caplog):
+    qa_filter = QAFilter()
+
+    with caplog.at_level(logging.WARNING):
+        result = qa_filter._parse_response({"pass": 3.14})
+
+    assert result.filter_passed is False
+    assert any("Falling back to False" in record.getMessage() for record in caplog.records)


### PR DESCRIPTION
## Summary
- add a QAFilter helper that normalises the `"pass"` field into a boolean, logging when inputs are invalid
- preserve additional response metadata while exposing a typed container for downstream consumers
- cover the string handling (including "false") and failure logging paths with new pytest tests
- ignore Python bytecode artefacts going forward

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd3567cec0832a8c7265ea68cf1749